### PR TITLE
LoadBalancer::getConnectionRef was deprecated in MediaWiki 1.39

### DIFF
--- a/src/LazyDBConnectionProvider.php
+++ b/src/LazyDBConnectionProvider.php
@@ -75,7 +75,7 @@ class LazyDBConnectionProvider implements DBConnectionProvider {
 
 			assert( $this->lb instanceof ILoadBalancer );
 
-			$this->connection = $this->lb->getConnectionRef( $this->connectionId, $this->groups, $this->wiki );
+			$this->connection = $this->lb->getConnection( $this->connectionId, $this->groups, $this->wiki );
 		}
 
 		assert( $this->connection instanceof IDatabase );


### PR DESCRIPTION
I am not sure if i did this correctly but this should be a fix for the below message when using **SubPageList (dev-master)** on **MW-1.43.0 (05cce96)** :

```
Deprecated:  
Use of Wikimedia\Rdbms\LoadBalancer::getConnectionRef was deprecated in MediaWiki 1.39. [Called from SubPageList\LazyDBConnectionProvider::getConnection in 
D:\Program Files\Apache\htdocs\testwiki\extensions\SubPageList\src\LazyDBConnectionProvider.php at line 78] in 
D:\Program Files\Apache\htdocs\testwiki\includes\debug\MWDebug.php on line 385
```
In the release notes of [MW-1.43](https://www.mediawiki.org/wiki/Release_notes/1.43) it says:

`LoadBalancer::getConnectionRef(), deprecated since 1.39, now emits deprecation warnings. Use ::getConnection() instead.`

And it actually fixed the issue, as far as I can see.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Optimized the system's database connectivity to enhance internal efficiency and consistency, resulting in a smoother and more reliable experience for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->